### PR TITLE
Script reloading when pressing Ctrl+R

### DIFF
--- a/Docs/CREATING-ADDONS.md
+++ b/Docs/CREATING-ADDONS.md
@@ -29,6 +29,12 @@ To get basic addon with simple plugin, follow these steps:
     * [Harmony documentation](https://harmony.pardeike.net/articles/intro.html) - Use it for patching the game's code at runtime.
     * [dnSpy](https://github.com/dnSpy/dnSpy) - for browsing the game's source code.
 
+## Addon Development
+
+By default, addons are only compiled once at start up. Starting the game with the `--live-reload` option will enable a new shortcut, `Ctrl+R`, to recompile and reload addons. You can add the option in the game's properties in Steam.
+
+With live reload enabled, be mindful of the plugin lifecycle - not disposing a resource created by an addon in its `Unload` method might lead to unexpected behaviours.
+
 ## Publishing your addon.
 We are supporting workshop! Yes! It's as simple as publishing your mod (created in step **11** above) to the workshop!
 

--- a/Source/Stationeers.Addons.PluginCompiler/Compiler.cs
+++ b/Source/Stationeers.Addons.PluginCompiler/Compiler.cs
@@ -106,7 +106,7 @@ namespace Stationeers.Addons.PluginCompiler
             Console.WriteLine($"Linking addon '{addonName}'...");
 
             var assemblyName = addonName + "-Assembly";
-            var compilation = CSharpCompilation.Create(assemblyName)
+            var compilation = CSharpCompilation.Create($"{assemblyName}-{DateTime.UtcNow.Ticks}")
                 .WithReferences(references.ToArray())
                 .WithOptions(options)
                 .AddSyntaxTrees(syntaxTrees);

--- a/Source/Stationeers.Addons/Core/LoaderManager.cs
+++ b/Source/Stationeers.Addons/Core/LoaderManager.cs
@@ -143,6 +143,25 @@ namespace Stationeers.Addons.Core
             }
         }
 
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.R) && Input.GetKey(KeyCode.LeftControl))
+            {
+                Debug.Log("REC update");
+                PluginLoader.UnloadAllPlugins();
+                StartCoroutine(Reload());
+            }
+        }
+
+        private IEnumerator Reload()
+        {
+            Debug.Log("REC recompiling");
+            yield return PluginCompiler.Load();
+            Debug.Log("REC reloading");
+            yield return PluginLoader.Load();
+            Debug.Log("REC done");
+        }
+
         private void OnDestroy()
         {
             foreach (var module in _modules)

--- a/Source/Stationeers.Addons/Core/LoaderManager.cs
+++ b/Source/Stationeers.Addons/Core/LoaderManager.cs
@@ -1,6 +1,7 @@
 ﻿// Stationeers.Addons (c) 2018-2021 Damian 'Erdroy' Korczowski & Contributors
 
 using System;
+using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;

--- a/Source/Stationeers.Addons/Core/LoaderManager.cs
+++ b/Source/Stationeers.Addons/Core/LoaderManager.cs
@@ -76,6 +76,8 @@ namespace Stationeers.Addons.Core
         public HarmonyModule Harmony { get; private set; }
 
         private bool _isRecompiling;
+        private bool _liveReloadEnabled;
+
 
         public void Activate()
         {
@@ -113,6 +115,8 @@ namespace Stationeers.Addons.Core
 
         private IEnumerator Start()
         {
+            _liveReloadEnabled =  System.Environment.GetCommandLineArgs().Any(a => a == "--live-reload");
+            Debug.Log("Live reload: " + _liveReloadEnabled);
             if(!IsDedicatedServer)
             {
                 ProgressPanel.Instance.ShowProgressBar("<b>Stationeers.Addons</b>");
@@ -148,7 +152,7 @@ namespace Stationeers.Addons.Core
 
         private void Update()
         {
-            if (!_isRecompiling && Input.GetKeyDown(KeyCode.R) && Input.GetKey(KeyCode.LeftControl))
+            if (_liveReloadEnabled && !_isRecompiling && Input.GetKeyDown(KeyCode.R) && Input.GetKey(KeyCode.LeftControl))
             {
                 _isRecompiling = true;
                 StartCoroutine(Reload());

--- a/Source/Stationeers.Addons/Modules/Plugins/PluginLoaderModule.cs
+++ b/Source/Stationeers.Addons/Modules/Plugins/PluginLoaderModule.cs
@@ -77,13 +77,22 @@ namespace Stationeers.Addons.Modules.Plugins
         /// <param name="pluginAssembly">The addon plugin assembly file</param>
         public void LoadPlugin(string addonName, string pluginAssembly)
         {
-            if (_plugins.ContainsKey(addonName))
+            if (_plugins.TryGetValue(addonName, out var prevPlugin))
             {
                 Debug.LogError("Plugin '" + addonName + "' already loaded!");
-                return;
+                foreach (var prevPluginPlugin in prevPlugin.Plugins)
+                {
+                    prevPluginPlugin.OnUnload();
+                }
+                prevPlugin.Assembly = null;
+                _plugins.Remove(addonName);
             }
 
-            var assembly = Assembly.LoadFile(pluginAssembly);
+            // the compiler could output a .pdb file, but AFAIK we'd need to convert it to .mdb using unity's pdb2mdb.exe
+            // load the raw bytes directly to avoid locking the dll
+            // note that the assembly name (not the file name) needs to be different every time, otherwise
+            // Assembly.Load will reuse the last loaded version
+            var assembly = Assembly.Load(File.ReadAllBytes(pluginAssembly));
 
             Debug.Log("Plugin assembly " + pluginAssembly + " loaded ");
 

--- a/Source/Stationeers.Addons/Modules/Plugins/PluginLoaderModule.cs
+++ b/Source/Stationeers.Addons/Modules/Plugins/PluginLoaderModule.cs
@@ -82,9 +82,15 @@ namespace Stationeers.Addons.Modules.Plugins
                 Debug.LogError("Plugin '" + addonName + "' already loaded!");
                 foreach (var prevPluginPlugin in prevPlugin.Plugins)
                 {
-                    prevPluginPlugin.OnUnload();
+                    try
+                    {
+                        prevPluginPlugin.OnUnload();
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogException(e);
+                    }
                 }
-                prevPlugin.Assembly = null;
                 _plugins.Remove(addonName);
             }
 
@@ -102,11 +108,18 @@ namespace Stationeers.Addons.Modules.Plugins
             {
                 if (typeof(IPlugin).IsAssignableFrom(type))
                 {
-                    var instance = (IPlugin)Activator.CreateInstance(type);
-                    instance.OnLoad();
-                    plugins.Add(instance);
+                    try
+                    {
+                        var instance = (IPlugin)Activator.CreateInstance(type);
+                        instance.OnLoad();
+                        plugins.Add(instance);
 
-                    Debug.Log("Activated plugin " + type);
+                        Debug.Log("Activated plugin " + type);
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogException(e);
+                    }
                 }
             }
 


### PR DESCRIPTION
loads dlls from memory to avoid locking them and generate a different assembly name when compiling them in the first place

raw version to start a discussion (eg. use a guid instead of now.ticks ? and definitely clean the remaining debug.log calls)