### PR TITLE
Add WorkshopManager Patch to Filter Files of C# Projects Out of Publish (and fix pdb2mdb bug)

### DIFF
--- a/Source/ExampleMod/ExampleMod.csproj
+++ b/Source/ExampleMod/ExampleMod.csproj
@@ -31,9 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Lib.Harmony.2.0.4\lib\net45\0Harmony.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="0Harmony">
+      <HintPath>..\packages\Lib.Harmony.2.0.4\lib\net45\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>$(SolutionDir)\..\Libraries\Stationeers\Assembly-CSharp.dll</HintPath>
@@ -114,6 +113,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>$(SolutionDir)packages\Mono.Unofficial.pdb2mdb.4.2.3.4\tools\pdb2mdb.exe "$(TargetPath)"</PostBuildEvent>
+    <PostBuildEvent>"$(SolutionDir)packages\Mono.Unofficial.pdb2mdb.4.2.3.4\tools\pdb2mdb.exe" "$(TargetPath)"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Source/ExampleMod/ExampleMod.csproj
+++ b/Source/ExampleMod/ExampleMod.csproj
@@ -31,8 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>..\packages\Lib.Harmony.2.0.4\lib\net45\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Lib.Harmony.2.0.4\lib\net45\0Harmony.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>$(SolutionDir)\..\Libraries\Stationeers\Assembly-CSharp.dll</HintPath>

--- a/Source/Stationeers.Addons/Modules/HarmonyLib/HarmonyModule.cs
+++ b/Source/Stationeers.Addons/Modules/HarmonyLib/HarmonyModule.cs
@@ -1,8 +1,11 @@
 ﻿// Stationeers.Addons (c) 2018-2021 Damian 'Erdroy' Korczowski & Contributors
 
 using System.Collections;
+using System.Reflection;
+using Assets.Scripts;
 using HarmonyLib;
 using Stationeers.Addons.Core;
+using Stationeers.Addons.Modules.Workshop;
 using UnityEngine;
 
 namespace Stationeers.Addons.Modules.HarmonyLib
@@ -25,6 +28,14 @@ namespace Stationeers.Addons.Modules.HarmonyLib
         /// <inheritdoc />
         public IEnumerator Load()
         {
+            Debug.Log("Patching WorkshopManager.PublishWorkshop using Harmony...");
+            MethodInfo publishWorkshopMethod = typeof(WorkshopManager).GetMethod("PublishWorkshop", BindingFlags.Public | BindingFlags.Instance);
+            MethodInfo onCreateItemMethod = typeof(WorkshopManager).GetMethod("OnCreateItem", BindingFlags.NonPublic | BindingFlags.Instance);
+            MethodInfo publishWorkshopPrefixMethod = typeof(WorkshopManagerPatch).GetMethod("PublishWorkshopPrefix");
+            MethodInfo onCreateItemPostfixMethod = typeof(WorkshopManagerPatch).GetMethod("OnCreateItemPostfix");
+            _harmony.Patch(publishWorkshopMethod, new HarmonyMethod(publishWorkshopPrefixMethod));
+            _harmony.Patch(onCreateItemMethod, null, new HarmonyMethod(onCreateItemPostfixMethod));
+
             Debug.Log("Patching game assembly using Harmony...");
             foreach (var plugin in LoaderManager.Instance.PluginLoader.LoadedPlugins)
             {

--- a/Source/Stationeers.Addons/Modules/HarmonyLib/HarmonyModule.cs
+++ b/Source/Stationeers.Addons/Modules/HarmonyLib/HarmonyModule.cs
@@ -34,12 +34,12 @@ namespace Stationeers.Addons.Modules.HarmonyLib
             try
             {
                 MethodInfo publishWorkshopMethod = typeof(WorkshopManager).GetMethod("PublishWorkshop", BindingFlags.Public | BindingFlags.Instance);
-                MethodInfo submitItemUpdateMethod = typeof(WorkshopManager).GetMethod("SubmitItemUpdate", BindingFlags.NonPublic | BindingFlags.Instance);
+                MethodInfo onSubmitItemUpdateMethod = typeof(WorkshopManager).GetMethod("OnSubmitItemUpdate", BindingFlags.NonPublic | BindingFlags.Instance);
                 MethodInfo publishWorkshopPrefixMethod = typeof(WorkshopManagerPatch).GetMethod("PublishWorkshopPrefix");
-                MethodInfo submitItemUpdatePostfixMethod = typeof(WorkshopManagerPatch).GetMethod("SubmitItemUpdatePostfix");
+                MethodInfo onSubmitItemUpdatePostfixMethod = typeof(WorkshopManagerPatch).GetMethod("OnSubmitItemUpdatePostfix");
 
                 _harmony.Patch(publishWorkshopMethod, new HarmonyMethod(publishWorkshopPrefixMethod));
-                _harmony.Patch(submitItemUpdateMethod, null, new HarmonyMethod(submitItemUpdatePostfixMethod));
+                _harmony.Patch(onSubmitItemUpdateMethod, null, new HarmonyMethod(onSubmitItemUpdatePostfixMethod));
             } 
             catch (Exception ex)
             {

--- a/Source/Stationeers.Addons/Modules/HarmonyLib/HarmonyModule.cs
+++ b/Source/Stationeers.Addons/Modules/HarmonyLib/HarmonyModule.cs
@@ -34,12 +34,12 @@ namespace Stationeers.Addons.Modules.HarmonyLib
             try
             {
                 MethodInfo publishWorkshopMethod = typeof(WorkshopManager).GetMethod("PublishWorkshop", BindingFlags.Public | BindingFlags.Instance);
-                MethodInfo onCreateItemMethod = typeof(WorkshopManager).GetMethod("OnCreateItem", BindingFlags.NonPublic | BindingFlags.Instance);
+                MethodInfo submitItemUpdateMethod = typeof(WorkshopManager).GetMethod("SubmitItemUpdate", BindingFlags.NonPublic | BindingFlags.Instance);
                 MethodInfo publishWorkshopPrefixMethod = typeof(WorkshopManagerPatch).GetMethod("PublishWorkshopPrefix");
-                MethodInfo onCreateItemPostfixMethod = typeof(WorkshopManagerPatch).GetMethod("OnCreateItemPostfix");
+                MethodInfo submitItemUpdatePostfixMethod = typeof(WorkshopManagerPatch).GetMethod("SubmitItemUpdatePostfix");
 
                 _harmony.Patch(publishWorkshopMethod, new HarmonyMethod(publishWorkshopPrefixMethod));
-                _harmony.Patch(onCreateItemMethod, null, new HarmonyMethod(onCreateItemPostfixMethod));
+                _harmony.Patch(submitItemUpdateMethod, null, new HarmonyMethod(submitItemUpdatePostfixMethod));
             } 
             catch (Exception ex)
             {

--- a/Source/Stationeers.Addons/Modules/HarmonyLib/HarmonyModule.cs
+++ b/Source/Stationeers.Addons/Modules/HarmonyLib/HarmonyModule.cs
@@ -33,10 +33,10 @@ namespace Stationeers.Addons.Modules.HarmonyLib
             Debug.Log("Patching WorkshopManager using Harmony...");
             try
             {
-                MethodInfo publishWorkshopMethod = typeof(WorkshopManager).GetMethod("PublishWorkshop", BindingFlags.Public | BindingFlags.Instance);
-                MethodInfo onSubmitItemUpdateMethod = typeof(WorkshopManager).GetMethod("OnSubmitItemUpdate", BindingFlags.NonPublic | BindingFlags.Instance);
-                MethodInfo publishWorkshopPrefixMethod = typeof(WorkshopManagerPatch).GetMethod("PublishWorkshopPrefix");
-                MethodInfo onSubmitItemUpdatePostfixMethod = typeof(WorkshopManagerPatch).GetMethod("OnSubmitItemUpdatePostfix");
+                var publishWorkshopMethod = typeof(WorkshopManager).GetMethod("PublishWorkshop", BindingFlags.Public | BindingFlags.Instance);
+                var onSubmitItemUpdateMethod = typeof(WorkshopManager).GetMethod("OnSubmitItemUpdate", BindingFlags.NonPublic | BindingFlags.Instance);
+                var publishWorkshopPrefixMethod = typeof(WorkshopManagerPatch).GetMethod("PublishWorkshopPrefix");
+                var onSubmitItemUpdatePostfixMethod = typeof(WorkshopManagerPatch).GetMethod("OnSubmitItemUpdatePostfix");
 
                 _harmony.Patch(publishWorkshopMethod, new HarmonyMethod(publishWorkshopPrefixMethod));
                 _harmony.Patch(onSubmitItemUpdateMethod, null, new HarmonyMethod(onSubmitItemUpdatePostfixMethod));

--- a/Source/Stationeers.Addons/Modules/HarmonyLib/HarmonyModule.cs
+++ b/Source/Stationeers.Addons/Modules/HarmonyLib/HarmonyModule.cs
@@ -1,8 +1,10 @@
 ﻿// Stationeers.Addons (c) 2018-2021 Damian 'Erdroy' Korczowski & Contributors
 
+using System;
 using System.Collections;
 using System.Reflection;
 using Assets.Scripts;
+using Assets.Scripts.UI;
 using HarmonyLib;
 using Stationeers.Addons.Core;
 using Stationeers.Addons.Modules.Workshop;
@@ -28,13 +30,22 @@ namespace Stationeers.Addons.Modules.HarmonyLib
         /// <inheritdoc />
         public IEnumerator Load()
         {
-            Debug.Log("Patching WorkshopManager.PublishWorkshop using Harmony...");
-            MethodInfo publishWorkshopMethod = typeof(WorkshopManager).GetMethod("PublishWorkshop", BindingFlags.Public | BindingFlags.Instance);
-            MethodInfo onCreateItemMethod = typeof(WorkshopManager).GetMethod("OnCreateItem", BindingFlags.NonPublic | BindingFlags.Instance);
-            MethodInfo publishWorkshopPrefixMethod = typeof(WorkshopManagerPatch).GetMethod("PublishWorkshopPrefix");
-            MethodInfo onCreateItemPostfixMethod = typeof(WorkshopManagerPatch).GetMethod("OnCreateItemPostfix");
-            _harmony.Patch(publishWorkshopMethod, new HarmonyMethod(publishWorkshopPrefixMethod));
-            _harmony.Patch(onCreateItemMethod, null, new HarmonyMethod(onCreateItemPostfixMethod));
+            Debug.Log("Patching WorkshopManager using Harmony...");
+            try
+            {
+                MethodInfo publishWorkshopMethod = typeof(WorkshopManager).GetMethod("PublishWorkshop", BindingFlags.Public | BindingFlags.Instance);
+                MethodInfo onCreateItemMethod = typeof(WorkshopManager).GetMethod("OnCreateItem", BindingFlags.NonPublic | BindingFlags.Instance);
+                MethodInfo publishWorkshopPrefixMethod = typeof(WorkshopManagerPatch).GetMethod("PublishWorkshopPrefix");
+                MethodInfo onCreateItemPostfixMethod = typeof(WorkshopManagerPatch).GetMethod("OnCreateItemPostfix");
+
+                _harmony.Patch(publishWorkshopMethod, new HarmonyMethod(publishWorkshopPrefixMethod));
+                _harmony.Patch(onCreateItemMethod, null, new HarmonyMethod(onCreateItemPostfixMethod));
+            } 
+            catch (Exception ex)
+            {
+                AlertPanel.Instance.ShowAlert($"Failed to initialize workshop publish patch!\n", AlertState.Alert);
+                Debug.LogError($"Failed to initialize workshop publish patch. Exception:\n{ex}");
+            }
 
             Debug.Log("Patching game assembly using Harmony...");
             foreach (var plugin in LoaderManager.Instance.PluginLoader.LoadedPlugins)

--- a/Source/Stationeers.Addons/Modules/Plugins/PluginCompilerModule.cs
+++ b/Source/Stationeers.Addons/Modules/Plugins/PluginCompilerModule.cs
@@ -88,6 +88,18 @@ namespace Stationeers.Addons.Modules.Plugins
 
                     var addonScripts = Directory.GetFiles(addonDirectory, "*.cs", SearchOption.AllDirectories);
 
+                    // Prevent mods that include the following files from defining duplicate attributes and screwing up compile.
+                    // */Properties/*
+                    // */bin/*
+                    // */obj/*
+                    List<string> sourceFilesList = new List<string>(addonScripts);
+
+                    sourceFilesList.RemoveAll(x => x.Contains(Path.DirectorySeparatorChar + "Properties" + Path.DirectorySeparatorChar));
+                    sourceFilesList.RemoveAll(x => x.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar));
+                    sourceFilesList.RemoveAll(x => x.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar));
+
+                    addonScripts = sourceFilesList.ToArray();
+
                     if (addonScripts.Length == 0) continue;
 
                     if (File.Exists(assemblyFile))

--- a/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
+++ b/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
@@ -23,7 +23,7 @@ namespace Stationeers.Addons.Modules.Workshop
                 Directory.CreateDirectory(strDestination);
             }
 
-            DirectoryInfo dirInfo = new DirectoryInfo(strSource);
+            var dirInfo = new DirectoryInfo(strSource);
             FileInfo[] files = dirInfo.GetFiles();
             foreach (FileInfo tempfile in files)
             {
@@ -44,7 +44,10 @@ namespace Stationeers.Addons.Modules.Workshop
             string tempItemContentPath = origItemContentPath + "_temp";
             __state = "";
 
-            DirectoryInfo tempItemContentDir = Directory.CreateDirectory(tempItemContentPath);
+            if (!Directory.Exists(tempItemContentPath))
+            {
+                Directory.CreateDirectory(tempItemContentPath);
+            }
 
             // Copy files to upload to temp directory, if they satisfy upload whitelist.
             foreach (string itemFilePath in Directory.GetFiles(origItemContentPath))

--- a/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
+++ b/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
@@ -1,0 +1,119 @@
+﻿using Assets.Scripts;
+using Assets.Scripts.Steam;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Stationeers.Addons.Modules.Workshop
+{
+    public class WorkshopManagerPatch
+    {
+        // Why does System.IO not have a directory copy method?
+        // Stolen from here: https://stackoverflow.com/questions/1974019/folder-copy-in-c-sharp
+        private static void copyDirectory(string strSource, string strDestination)
+        {
+            if (!Directory.Exists(strDestination))
+            {
+                Directory.CreateDirectory(strDestination);
+            }
+
+            DirectoryInfo dirInfo = new DirectoryInfo(strSource);
+            FileInfo[] files = dirInfo.GetFiles();
+            foreach (FileInfo tempfile in files)
+            {
+                tempfile.CopyTo(Path.Combine(strDestination, tempfile.Name));
+            }
+
+            DirectoryInfo[] directories = dirInfo.GetDirectories();
+            foreach (DirectoryInfo tempdir in directories)
+            {
+                copyDirectory(Path.Combine(strSource, tempdir.Name), Path.Combine(strDestination, tempdir.Name));
+            }
+
+        }
+
+        public static void PublishWorkshopPrefix(WorkshopManager __instance, ref WorkShopItemDetail ItemDetail, ref string changeNote, out string __state)
+        {
+            string origItemContentPath = ItemDetail.Path;
+            string tempItemContentPath = origItemContentPath + "_temp";
+            __state = "";
+
+            DirectoryInfo tempItemContentDir = Directory.CreateDirectory(tempItemContentPath);
+
+            // Copy files to upload to temp directory, if they satisfy upload whitelist.
+            foreach (string itemFilePath in Directory.GetFiles(origItemContentPath))
+            {
+                bool validFile = false;
+                string fileName = new FileInfo(itemFilePath).Name;
+
+                // Ugly fall-through regex party.
+                if (new Regex(@".*\.cs$").IsMatch(fileName))
+                    validFile = true;
+
+                if (new Regex(@".*\.xml$").IsMatch(fileName))
+                    validFile = true;
+
+                if (new Regex(@".*\.png$").IsMatch(fileName))
+                    validFile = true;
+
+                if (new Regex(@".*\.asset$").IsMatch(fileName))
+                    validFile = true;
+
+                if (new Regex(@"^LICENSE$").IsMatch(fileName))
+                    validFile = true;
+
+                if (validFile)
+                    File.Copy(itemFilePath, tempItemContentPath + Path.GetFileName(itemFilePath));
+            }
+
+            // Copy directories to upload to temp directory, if they satisfy upload whitelist.
+            foreach (string itemFolderPath in Directory.GetDirectories(origItemContentPath))
+            {
+                bool validDir = false;
+                string dirName = new DirectoryInfo(itemFolderPath).Name;
+
+                // Ugly fall-through regex party.
+                if (new Regex(@"^About$").IsMatch(dirName))
+                    validDir = true;
+
+                if (new Regex(@"^Content$").IsMatch(dirName))
+                    validDir = true;
+
+                if (new Regex(@"^GameData$").IsMatch(dirName))
+                    validDir = true;
+
+                if (new Regex(@"^Scripts$").IsMatch(dirName))
+                    validDir = true;
+
+                if (validDir)
+                    copyDirectory(itemFolderPath, tempItemContentPath + Path.DirectorySeparatorChar + dirName);
+            }
+
+            // Set workshop item info to use temporary path before ISteamUCG gets its hands on it.
+            ItemDetail.Path = tempItemContentPath;
+
+            // Save state for later nuking.
+            Debug.Log("Created temporary workshop item directory " + __state);
+            __state = tempItemContentPath;
+        }
+
+        public static void OnCreateItemPostfix(WorkshopManager __instance, SteamAsyncCreateItem Parent, bool WasSuccessful, WorkShopItemDetail ItemDetail, bool UserNeedsToAcceptWorkshopLegalAgreement)
+        {
+            string origItemContentPath = ItemDetail.Path;
+            string tempItemContentPath = origItemContentPath + "_temp";
+
+            if (Directory.Exists(tempItemContentPath))
+            {
+                // Recursively remove the temp dir after steam is done with it.
+                Debug.Log("Cleared temporary workshop item directory " + tempItemContentPath);
+                Directory.Delete(tempItemContentPath, true);
+            }
+        }
+    }
+}

--- a/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
+++ b/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
@@ -77,7 +77,7 @@ namespace Stationeers.Addons.Modules.Workshop
             Debug.Log("Created temporary workshop item directory " + tempItemContentPath);
         }
 
-        public static void SubmitItemUpdatePostfix(WorkshopManager __instance, UGCUpdateHandle_t UGCUpdateHandle, WorkShopItemDetail ItemDetail)
+        public static void OnSubmitItemUpdatePostfix(WorkshopManager __instance, SteamAsyncSubmitItemUpdate Parent, bool WasSuccessful, WorkShopItemDetail ItemDetail, bool UserNeedsToAcceptWorkshopLegalAgreement)
         {
             string tempItemContentPath = ItemDetail.Path;
             string origItemContentPath = tempItemContentPath.Replace("_temp", "");

--- a/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
+++ b/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
@@ -1,6 +1,7 @@
 ﻿using Assets.Scripts;
 using Assets.Scripts.Steam;
 using HarmonyLib;
+using Steamworks;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -76,17 +77,21 @@ namespace Stationeers.Addons.Modules.Workshop
             Debug.Log("Created temporary workshop item directory " + tempItemContentPath);
         }
 
-        public static void OnCreateItemPostfix(WorkshopManager __instance, SteamAsyncCreateItem Parent, bool WasSuccessful, WorkShopItemDetail ItemDetail, bool UserNeedsToAcceptWorkshopLegalAgreement)
+        public static void SubmitItemUpdatePostfix(WorkshopManager __instance, UGCUpdateHandle_t UGCUpdateHandle, WorkShopItemDetail ItemDetail)
         {
-            string origItemContentPath = ItemDetail.Path;
-            string tempItemContentPath = origItemContentPath + "_temp";
+            string tempItemContentPath = ItemDetail.Path;
+            string origItemContentPath = tempItemContentPath.Replace("_temp", "");
 
-            if (Directory.Exists(tempItemContentPath))
+            Debug.Log("Checking for temporary workshop item directory " + tempItemContentPath);
+            if (Directory.Exists(tempItemContentPath) && tempItemContentPath.Contains("_temp"))
             {
                 // Recursively remove the temp dir after steam is done with it.
                 Debug.Log("Cleared temporary workshop item directory " + tempItemContentPath);
                 Directory.Delete(tempItemContentPath, true);
             }
+
+            // Put things back how we found them
+            ItemDetail.Path = origItemContentPath;
         }
 
         private static readonly Regex[] ValidFileNames =
@@ -101,7 +106,7 @@ namespace Stationeers.Addons.Modules.Workshop
         private static readonly Regex[] ValidDirectoryNames =
         {
             new Regex(@"^About$"),
-            new Regex(@"^Content"),
+            new Regex(@"^Content$"),
             new Regex(@"^GameData$"),
             new Regex(@"^Scripts$")
         };

--- a/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
+++ b/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
@@ -25,14 +25,14 @@ namespace Stationeers.Addons.Modules.Workshop
             }
 
             var dirInfo = new DirectoryInfo(strSource);
-            FileInfo[] files = dirInfo.GetFiles();
-            foreach (FileInfo tempfile in files)
+            var files = dirInfo.GetFiles();
+            foreach (var tempfile in files)
             {
                 tempfile.CopyTo(Path.Combine(strDestination, tempfile.Name));
             }
 
-            DirectoryInfo[] directories = dirInfo.GetDirectories();
-            foreach (DirectoryInfo tempdir in directories)
+            var directories = dirInfo.GetDirectories();
+            foreach (var tempdir in directories)
             {
                 CopyDirectory(Path.Combine(strSource, tempdir.Name), Path.Combine(strDestination, tempdir.Name));
             }
@@ -41,8 +41,8 @@ namespace Stationeers.Addons.Modules.Workshop
 
         public static void PublishWorkshopPrefix(WorkshopManager __instance, ref WorkShopItemDetail ItemDetail, ref string changeNote)
         {
-            string origItemContentPath = ItemDetail.Path;
-            string tempItemContentPath = origItemContentPath + "_temp";
+            var origItemContentPath = ItemDetail.Path;
+            var tempItemContentPath = origItemContentPath + "_temp";
 
             if (!Directory.Exists(tempItemContentPath))
             {
@@ -50,9 +50,9 @@ namespace Stationeers.Addons.Modules.Workshop
             }
 
             // Copy files to upload to temp directory, if they satisfy upload whitelist.
-            foreach (string itemFilePath in Directory.GetFiles(origItemContentPath))
+            foreach (var itemFilePath in Directory.GetFiles(origItemContentPath))
             {
-                string fileName = new FileInfo(itemFilePath).Name;
+                var fileName = new FileInfo(itemFilePath).Name;
 
                 var validFile = ValidFileNames.Any(regex => regex.IsMatch(fileName));
 
@@ -63,7 +63,7 @@ namespace Stationeers.Addons.Modules.Workshop
             // Copy directories to upload to temp directory, if they satisfy upload whitelist.
             foreach (string itemFolderPath in Directory.GetDirectories(origItemContentPath))
             {
-                string dirName = new FileInfo(itemFolderPath).Name;
+                var dirName = new FileInfo(itemFolderPath).Name;
 
                 var validDir = ValidDirectoryNames.Any(regex => regex.IsMatch(dirName));
 

--- a/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
+++ b/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
@@ -52,24 +52,9 @@ namespace Stationeers.Addons.Modules.Workshop
             // Copy files to upload to temp directory, if they satisfy upload whitelist.
             foreach (string itemFilePath in Directory.GetFiles(origItemContentPath))
             {
-                bool validFile = false;
                 string fileName = new FileInfo(itemFilePath).Name;
 
-                // Ugly fall-through regex party.
-                if (new Regex(@".*\.cs$").IsMatch(fileName))
-                    validFile = true;
-
-                if (new Regex(@".*\.xml$").IsMatch(fileName))
-                    validFile = true;
-
-                if (new Regex(@".*\.png$").IsMatch(fileName))
-                    validFile = true;
-
-                if (new Regex(@".*\.asset$").IsMatch(fileName))
-                    validFile = true;
-
-                if (new Regex(@"^LICENSE$").IsMatch(fileName))
-                    validFile = true;
+                var validFile = ValidFileNames.Any(regex => regex.IsMatch(fileName));
 
                 if (validFile)
                     File.Copy(itemFilePath, tempItemContentPath + Path.GetFileName(itemFilePath));
@@ -78,21 +63,9 @@ namespace Stationeers.Addons.Modules.Workshop
             // Copy directories to upload to temp directory, if they satisfy upload whitelist.
             foreach (string itemFolderPath in Directory.GetDirectories(origItemContentPath))
             {
-                bool validDir = false;
-                string dirName = new DirectoryInfo(itemFolderPath).Name;
+                string dirName = new FileInfo(itemFolderPath).Name;
 
-                // Ugly fall-through regex party.
-                if (new Regex(@"^About$").IsMatch(dirName))
-                    validDir = true;
-
-                if (new Regex(@"^Content$").IsMatch(dirName))
-                    validDir = true;
-
-                if (new Regex(@"^GameData$").IsMatch(dirName))
-                    validDir = true;
-
-                if (new Regex(@"^Scripts$").IsMatch(dirName))
-                    validDir = true;
+                var validDir = ValidDirectoryNames.Any(regex => regex.IsMatch(dirName));
 
                 if (validDir)
                     CopyDirectory(itemFolderPath, tempItemContentPath + Path.DirectorySeparatorChar + dirName);
@@ -118,5 +91,22 @@ namespace Stationeers.Addons.Modules.Workshop
                 Directory.Delete(tempItemContentPath, true);
             }
         }
+
+        private static readonly Regex[] ValidFileNames =
+        {
+            new Regex(@".*\.cs$"),
+            new Regex(@".*\.xml$"),
+            new Regex(@".*\.png$"),
+            new Regex(@".*\.asset$"),
+            new Regex(@"^LICENSE$")
+        };
+
+        private static readonly Regex[] ValidDirectoryNames =
+        {
+            new Regex(@"^About$"),
+            new Regex(@"^Content"),
+            new Regex(@"^GameData$"),
+            new Regex(@"^Scripts$")
+        };
     }
 }

--- a/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
+++ b/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
@@ -16,7 +16,7 @@ namespace Stationeers.Addons.Modules.Workshop
     {
         // Why does System.IO not have a directory copy method?
         // Stolen from here: https://stackoverflow.com/questions/1974019/folder-copy-in-c-sharp
-        private static void copyDirectory(string strSource, string strDestination)
+        private static void CopyDirectory(string strSource, string strDestination)
         {
             if (!Directory.Exists(strDestination))
             {
@@ -33,7 +33,7 @@ namespace Stationeers.Addons.Modules.Workshop
             DirectoryInfo[] directories = dirInfo.GetDirectories();
             foreach (DirectoryInfo tempdir in directories)
             {
-                copyDirectory(Path.Combine(strSource, tempdir.Name), Path.Combine(strDestination, tempdir.Name));
+                CopyDirectory(Path.Combine(strSource, tempdir.Name), Path.Combine(strDestination, tempdir.Name));
             }
 
         }
@@ -92,7 +92,7 @@ namespace Stationeers.Addons.Modules.Workshop
                     validDir = true;
 
                 if (validDir)
-                    copyDirectory(itemFolderPath, tempItemContentPath + Path.DirectorySeparatorChar + dirName);
+                    CopyDirectory(itemFolderPath, tempItemContentPath + Path.DirectorySeparatorChar + dirName);
             }
 
             // Set workshop item info to use temporary path before ISteamUCG gets its hands on it.

--- a/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
+++ b/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
@@ -38,11 +38,10 @@ namespace Stationeers.Addons.Modules.Workshop
 
         }
 
-        public static void PublishWorkshopPrefix(WorkshopManager __instance, ref WorkShopItemDetail ItemDetail, ref string changeNote, out string __state)
+        public static void PublishWorkshopPrefix(WorkshopManager __instance, ref WorkShopItemDetail ItemDetail, ref string changeNote)
         {
             string origItemContentPath = ItemDetail.Path;
             string tempItemContentPath = origItemContentPath + "_temp";
-            __state = "";
 
             if (!Directory.Exists(tempItemContentPath))
             {
@@ -74,9 +73,7 @@ namespace Stationeers.Addons.Modules.Workshop
             // Set workshop item info to use temporary path before ISteamUCG gets its hands on it.
             ItemDetail.Path = tempItemContentPath;
 
-            // Save state for later nuking.
-            Debug.Log("Created temporary workshop item directory " + __state);
-            __state = tempItemContentPath;
+            Debug.Log("Created temporary workshop item directory " + tempItemContentPath);
         }
 
         public static void OnCreateItemPostfix(WorkshopManager __instance, SteamAsyncCreateItem Parent, bool WasSuccessful, WorkShopItemDetail ItemDetail, bool UserNeedsToAcceptWorkshopLegalAgreement)

--- a/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
+++ b/Source/Stationeers.Addons/Modules/Workshop/WorkshopManagerPatch.cs
@@ -13,7 +13,7 @@ using UnityEngine;
 
 namespace Stationeers.Addons.Modules.Workshop
 {
-    public class WorkshopManagerPatch
+    public static class WorkshopManagerPatch
     {
         // Why does System.IO not have a directory copy method?
         // Stolen from here: https://stackoverflow.com/questions/1974019/folder-copy-in-c-sharp

--- a/Source/Stationeers.Addons/Stationeers.Addons.csproj
+++ b/Source/Stationeers.Addons/Stationeers.Addons.csproj
@@ -33,7 +33,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="0Harmony">
       <HintPath>..\packages\Lib.Harmony.2.0.4\lib\net45\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
@@ -117,6 +117,7 @@
     <Compile Include="Modules\IModule.cs" />
     <Compile Include="Modules\LiveReload\LiveReloadModule.cs" />
     <Compile Include="Modules\Plugins\PluginLoaderModule.cs" />
+    <Compile Include="Modules\Workshop\WorkshopManagerPatch.cs" />
     <Compile Include="Modules\Workshop\WorkshopModule.cs" />
     <Compile Include="IPlugin.cs" />
     <Compile Include="Core\LoaderManager.cs" />
@@ -131,6 +132,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>$(SolutionDir)packages\Mono.Unofficial.pdb2mdb.4.2.3.4\tools\pdb2mdb.exe "$(TargetPath)"</PostBuildEvent>
+    <PostBuildEvent>"$(SolutionDir)packages\Mono.Unofficial.pdb2mdb.4.2.3.4\tools\pdb2mdb.exe" "$(TargetPath)"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Source/Stationeers.Addons/Stationeers.Addons.csproj
+++ b/Source/Stationeers.Addons/Stationeers.Addons.csproj
@@ -33,7 +33,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
+    <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Lib.Harmony.2.0.4\lib\net45\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">

--- a/Source/Stationeers.Addons/Stationeers.Addons.csproj
+++ b/Source/Stationeers.Addons/Stationeers.Addons.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Modules\Plugins\PluginCompiler.cs" />
     <Compile Include="Modules\Plugins\PluginCompilerModule.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utilities\DirectoryEx.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Source/Stationeers.Addons/Utilities/DirectoryEx.cs
+++ b/Source/Stationeers.Addons/Utilities/DirectoryEx.cs
@@ -1,0 +1,36 @@
+// Stationeers.Addons (c) 2018-2021 Damian 'Erdroy' Korczowski & Contributors
+
+using System.IO;
+
+namespace Stationeers.Addons.Utilities
+{
+    public static class DirectoryEx
+    {
+        /// <summary>
+        ///     Copies contents of source into the destination directory.
+        /// </summary>
+        /// <param name="source">The source directory path.</param>
+        /// <param name="destination">The destination directory path (will be created if does not exist).</param>
+        public static void Copy(string source, string destination)
+        {
+            // Source: https://stackoverflow.com/questions/1974019/folder-copy-in-c-sharp
+
+            if (!Directory.Exists(destination))
+                Directory.CreateDirectory(destination);
+
+            var dirInfo = new DirectoryInfo(source);
+            var files = dirInfo.GetFiles();
+            var directories = dirInfo.GetDirectories();
+
+            foreach (var file in files)
+            {
+                file.CopyTo(Path.Combine(destination, file.Name));
+            }
+
+            foreach (var tempDirectory in directories)
+            {
+                Copy(Path.Combine(source, tempDirectory.Name), Path.Combine(destination, tempDirectory.Name));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Can now stuff most C# project files in a mod directory with little worry.

Also fixed lack of quotes around pdb2mdb to stop issues with directories with spaces in path.

Trellos of interest:
https://trello.com/c/CWySQvTW
https://trello.com/c/5D1Q8ly2

See attached example mod uploaded without extra files:
https://steamcommunity.com/sharedfiles/filedetails/?id=2602443402



