### PR TITLE
adding linux client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,26 @@
 **Current status:** Available for early testing.<br>
 
 ## Download & Installation
+### Windows
 If you have already installed the Addons, make sure to run file verification through Steam before installing a new version (go to Steam, click RMB on the game, open **Properties**, go to **Local Files** and click on **Verify integrity of game files...**)!
  
 Go to [Releases](https://github.com/Erdroy/Stationeers.Addons/releases), select latest release and download zip file named 'Stationeers.Addons-vX.X-X.zip'. Now go to Steam, click RMB on the game, open **Properties**, go to **Local Files** and click on **BROWSE LOCAL FILES**. It should open new window for you. Next, you have to open the downloaded zip and drag all of its contents into the game folder (`AddonManager` folder and `version.dll`). And that's it! Enjoy your mods!
 
 ***Note:** After you've subscribed to an addon on the workshop, you have to restart the game. This will be improved in the future.*
+
+### Linux (client, not tested for servers)
+*(this is in beta, might not work)*
+Installing:
+1) Do the same unzipping as in windows (extract all zip content on the game installation root folder)
+2) In a shell, navigate to the Addons folder you've just extracted
+3) Run `mono Stationeers.Addons.Patcher.exe`
+4) Enjoy (hopefully)
+
+Updating:
+1) Like in windows, verify the files from steam
+2) Extract new version of this package
+3) Run the exe (step 3 of `Installing`)
+
 
 ## Links
 * [Discord](https://discord.gg/b6kFrUATdm)

--- a/Source/Stationeers.Addons.Patcher/Core/Patchers/MonoPatcher.cs
+++ b/Source/Stationeers.Addons.Patcher/Core/Patchers/MonoPatcher.cs
@@ -133,10 +133,10 @@ namespace Stationeers.Addons.Patcher.Core.Patchers
             {
                 _installResourcesDir = Constants.ServerResourcesDir;
             }
-            System.Diagnostics.Debug.Assert(!string.IsNullOrEmpty(installResourcesDir), "Invalid install dir!");
+            System.Diagnostics.Debug.Assert(!string.IsNullOrEmpty(_installResourcesDir), "Invalid install dir!");
 
-            AssemblyFileName = Path.Combine(Environment.CurrentDirectory, installResourcesDir, AssemblyDir, AssemblyName);
-            TemporaryAssemblyFileName = Path.Combine(Environment.CurrentDirectory, installResourcesDir, AssemblyDir, AssemblyName + ".temp.dll");
+            AssemblyFileName = Path.Combine(Environment.CurrentDirectory, _installResourcesDir, AssemblyDir, AssemblyName);
+            TemporaryAssemblyFileName = Path.Combine(Environment.CurrentDirectory, _installResourcesDir, AssemblyDir, AssemblyName + ".temp.dll");
         }
 
         private void Backup()


### PR DESCRIPTION
Current Behavior On linux:
1) Without running the patcher,  nothing really happens, the game loads as if nothing was done
2) After running the original patcher:
An error occurs  trying to load the `Stationeers.Addons.dll` saying basically that `Assembly.LoadFile` requires an absolute path (this is code generated by cecil, also this happens inside the game, in the F3 console)

New Behavior:
1) Without running the patcher,  nothing really happens, the game loads as if nothing was done
2) After running the new patcher:
Starting the game now shows 2 loading bars (for the Loading scene, removing prefabs, etc), not sure why.
Once on the menu the addon compiles the plugins (the progress bar is shown in the menu)
Loading a world should load plugins installed (tested with [network painter](https://steamcommunity.com/sharedfiles/filedetails/?id=2876605527))

What this change does:
It Path.Combines the runtime `Environment.CurrentDirectory` (meaning while running the game), and with the `Stationeers.Addons.dll` to get the full path.

It also copies all the required assemblies (from `Stationeers.Addons project`) to the `rocketstation_Data/Managed` folder, which seems to be auto loaded be mono, so all dlls there become available to the mods
